### PR TITLE
added kdtree support and example

### DIFF
--- a/examples/kdtree.py
+++ b/examples/kdtree.py
@@ -1,0 +1,29 @@
+import pcl
+import numpy as np
+points_1 = np.array([0,0,0,
+                     1,0,0,
+                     0,1,0,
+                     1,1,0], dtype=np.float32).reshape([4,3])
+points_2 = np.array([0,0,0.2,
+                     1,0,0,
+                     0,1,0,
+                     1.1,1,0.5], dtype=np.float32).reshape([4,3])
+
+print 'pc_1:'
+print points_1
+print '\npc_2:'
+print points_2
+print '\n'
+pc_1 = pcl.PointCloud()
+pc_1.from_array(points_1)
+pc_2 = pcl.PointCloud()
+pc_2.from_array(points_2)
+kd = pc_1.make_kdtree_flann()
+# find the single closest points to each point in point cloud 2
+# (and the sqr distances)
+indices, sqr_distances = kd.nearest_k_search_for_cloud(pc_2, 1)
+for i in range(pc_1.size):
+    print 'index of the closest point in pc_1 to point ' + `i` + \
+        ' in pc_2 is ' + `indices[i,0]`
+    print 'the squared distance between these two points is ' + \
+        `sqr_distances[i,0]` + '\n'

--- a/pcl_defs.pxd
+++ b/pcl_defs.pxd
@@ -163,3 +163,12 @@ cdef extern from "pcl/filters/passthrough.h" namespace "pcl":
 
 ctypedef PassThrough[PointXYZ] PassThrough_t
 
+cdef extern from "pcl/kdtree/kdtree_flann.h" namespace "pcl":
+    cdef cppclass KdTreeFLANN[T]:
+        KdTreeFLANN()
+        void setInputCloud (shared_ptr[PointCloud[T]])
+        int nearestKSearch (PointCloud[T],
+          int, int, vector[int], vector[float])
+
+ctypedef KdTreeFLANN[PointXYZ] KdTreeFLANN_t
+


### PR DESCRIPTION
using the same approach as in the rest of the wrapper, wrapped
`pcl::KdTreeFLANN` from `pcl/kdtree/kdtree_flann.h`. As in other cases,
appended a `make_kdtree_flann` function to the `PointCloud` class.
At this stage, the only method exposed is `nearestKSearch`,
in particular the version which takes a `PointCloud` and an index into
it to choose the points for comparison:
http://bit.ly/WWI9JS

Further added a convienience method which finds the k nearest
distances for all points in the provided point cloud. For an example,
see `examples/kdtree.py`
