### PR TITLE
Function to compute normals

### DIFF
--- a/pcl_defs.pxd
+++ b/pcl_defs.pxd
@@ -26,7 +26,11 @@ cdef extern from "pcl/point_types.h" namespace "pcl":
         float y
         float z
     cdef struct Normal:
-        pass
+        Normal()
+        float normal_x
+        float normal_y
+        float normal_z
+        float curvature
 
 cdef extern from "pcl/features/normal_3d.h" namespace "pcl":
     cdef cppclass NormalEstimation[T, N]:

--- a/tests/test.py
+++ b/tests/test.py
@@ -208,6 +208,18 @@ class TestExtract(unittest.TestCase):
         self.assertNotEqual(self.p, p2)
         self.assertEqual(p2.size, self.p.size - 3)
 
+class TestCalcNormals(unittest.TestCase):
+
+    def setUp(self):
+        self.p = pcl.PointCloud()
+        self.p.from_list([[0,0,0],[1,0,0],[0,1,0]])
+
+    def testCalcNormals(self):
+        normals = self.p.calc_normals(20)
+        truth = np.array([[0,0,1],[0,0,1],[0,0,1]])
+        self.assertEqual(normals, truth)
+        self.assertEqual(normals.size, self.p.size)
+
 class TestSegmenterNormal(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Normals were already being calculated in make_segmenter_normals(). I created a new function that outputs this set of normals.

Example:
import pcl
cloud = pcl.PointCloud()
cloud.from_file("tests/table_scene_mug_stereo_textured_noplane.pcd")
n = cloud.calc_normals(50)
