### PR TITLE
Computing Normals

### DIFF
--- a/pcl.pyx
+++ b/pcl.pyx
@@ -438,14 +438,14 @@ cdef class MovingLeastSquares:
         """
         self.me.setPolynomialFit(fit)
 
-    def process(self):
+    def reconstruct(self):
         """
         Apply the smoothing according to the previously set values and return
         a new pointcloud
         """
         pc = PointCloud()
         cdef cpp.PointCloud_t *ccloud = <cpp.PointCloud_t *>pc.thisptr
-        self.me.process(deref(ccloud))
+        self.me.reconstruct(deref(ccloud))
         return pc
 
 cdef class VoxelGridFilter:

--- a/pcl_defs.pxd
+++ b/pcl_defs.pxd
@@ -63,15 +63,15 @@ ctypedef SACSegmentation[PointXYZ] SACSegmentation_t
 ctypedef SACSegmentationFromNormals[PointXYZ,Normal] SACSegmentationNormal_t
 
 cdef extern from "pcl/surface/mls.h" namespace "pcl":
-    cdef cppclass MovingLeastSquares[I,O]:
+    cdef cppclass MovingLeastSquares[I,N]:
         MovingLeastSquares()
         void setInputCloud (shared_ptr[PointCloud[I]])
         void setSearchRadius (double)
         void setPolynomialOrder(bool)
         void setPolynomialFit(int)
-        void process (PointCloud[O])
+        void reconstruct (PointCloud[I])
 
-ctypedef MovingLeastSquares[PointXYZ,PointXYZ] MovingLeastSquares_t
+ctypedef MovingLeastSquares[PointXYZ,Normal] MovingLeastSquares_t
 
 cdef extern from "pcl/search/kdtree.h" namespace "pcl::search":
     cdef cppclass KdTree[T]:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='python-pcl',
       ext_modules=[Extension(
                    "pcl",
                    ["pcl.pyx", "minipcl.cpp"],
-                    include_dirs=["/usr/include/pcl-1.6", "/usr/include/eigen3/"],
+                    include_dirs=["/usr/include/pcl-1.5", "/usr/include/eigen3/"],
                     libraries=["pcl_segmentation", "pcl_io", "OpenNI",
                                "usb-1.0", "pcl_filters", "pcl_sample_consensus",
                                "pcl_features", "pcl_surface", "pcl_search", "pcl_kdtree", "pcl_octree",

--- a/tests/test.py
+++ b/tests/test.py
@@ -185,7 +185,7 @@ class TestFilter(unittest.TestCase):
         mls.set_search_radius(0.5)
         mls.set_polynomial_order(2)
         mls.set_polynomial_fit(True)
-        f = mls.process()
+        f = mls.reconstruct()
         #new instance is returned
         self.assertNotEqual(self.p, f)
         #mls filter retains the same number of points


### PR DESCRIPTION
This PR should be easier to merge. 

compute_normals() has been added to expose the PCL function for calculating surface normals.
