### PR TITLE
cut pkgconfig dependency

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -60,11 +60,10 @@ This work was supported by `Strawlab <http://strawlab.org/>`_.
 Requirements
 ------------
 
-This release has been tested on Ubuntu 12.10 with
+This release has been tested on Ubuntu 13.10 with
 
  * pcl 1.7.1
  * Cython 0.20
- * `pkgconfig <https://pypi.python.org/pypi/pkgconfig>` 1.10
 
 A note about types
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,37 @@
+from collections import defaultdict
+from Cython.Distutils import build_ext
 from distutils.core import setup
 from distutils.extension import Extension
-from Cython.Distutils import build_ext
-import pkgconfig
+import subprocess
 
 PCL_VER = "1.7"
 
+# Find build/link options for PCL using pkg-config.
 pcl_libs = ["common", "features", "filters", "io", "kdtree", "octree",
             "sample_consensus", "search", "segmentation", "surface"]
+pcl_libs = ["pcl_%s-%s" % (lib, PCL_VER) for lib in pcl_libs]
 
-ext_args = pkgconfig.parse(' '.join('pcl_%s-%s' % (lib, PCL_VER)
-                                    for lib in pcl_libs))
+ext_args = defaultdict(list)
 
-for key in ext_args:
-    # Work around Unicode issue in some versions of distutils. Assume UTF-8.
-    ext_args[key] = [val.decode('utf-8') for val in ext_args[key]]
+
+def pkgconfig(flag):
+    return subprocess.check_output(['pkg-config', flag] + pcl_libs).split()
+
+for flag in pkgconfig('--cflags-only-I'):
+    ext_args['include_dirs'].append(flag[2:])
+for flag in pkgconfig('--cflags-only-other'):
+    if flag.startswith('-D'):
+        macro, value = flag[2:].split('=', 1)
+        ext_args['define_macros'].append((macro, value))
+    else:
+        ext_args['extra_compile_args'].append(flag)
+for flag in pkgconfig('--libs-only-l'):
+    ext_args['libraries'].append(flag[2:])
+for flag in pkgconfig('--libs-only-L'):
+    ext_args['library_dirs'].append(flag[2:])
+for flag in pkgconfig('--libs-only-other'):
+    ext_args['extra_link_args'].append(flag)
+
 
 setup(name='python-pcl',
       description='pcl wrapper',


### PR DESCRIPTION
Here's a new `setup.py` that calls `pkg-config` using `subprocess` instead of using a library. It's less code than I expected, long live Python :)
