### PR TITLE
Check multiple PCL versions in setup.py + Python 2.6 support

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -62,8 +62,15 @@ Requirements
 
 This release has been tested on Ubuntu 13.10 with
 
+ * Python 2.7.5
  * pcl 1.7.1
- * Cython 0.20
+ * Cython 0.20.2
+
+and CentOS 6.5 with
+
+ * Python 2.6.6
+ * pcl 1.6.0
+ * Cython 0.20.2
 
 A note about types
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,14 @@ ext_args = defaultdict(list)
 
 
 def pkgconfig(flag):
-    return subprocess.check_output(['pkg-config', flag] + pcl_libs).split()
+    # Equivalent in Python 2.7 (but not 2.6):
+    #subprocess.check_output(['pkg-config', flag] + pcl_libs).split()
+    p = subprocess.Popen(['pkg-config', flag] + pcl_libs,
+                         stdout=subprocess.PIPE)
+    stdout, _ = p.communicate()
+    # Assume no evil spaces in filenames; unsure how pkg-config would
+    # handle those, anyway.
+    return stdout.split()
 
 
 for flag in pkgconfig('--cflags-only-I'):


### PR DESCRIPTION
I've updated `setup.py` so that the package now builds with Python 2.6 and PCL 1.6 or 1.7. It's a bit long, but that's because `setup.py` tries to explain what it did when something goes wrong with `pkg-config`, which is useful for debugging.
