### PR TITLE
optimize k-NN searches (no Python code in loops)

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -310,6 +310,7 @@ class TestKdTree(unittest.TestCase):
 
     def testException(self):
         self.assertRaises(TypeError, pcl.KdTreeFLANN)
+        self.assertRaises(TypeError, self.kd.nearest_k_search_for_cloud, None)
 
     def testKNN(self):
         # Small cluster
@@ -324,7 +325,6 @@ class TestKdTree(unittest.TestCase):
         for ref, k in ((80, 1), (59, 3), (60, 10)):
             ind, sqdist = self.kd.nearest_k_search_for_point(self.pc, ref, k=k)
             for i in ind:
-                self.assertGreaterEqual(i, 0)
                 self.assertGreaterEqual(i, 30)
             for d in sqdist:
                 self.assertGreaterEqual(d, 0)


### PR DESCRIPTION
Body of `_nearest_k` is entirely white in `cython -a` output.

Performance:

``` python
>>> import numpy as np
>>> import pcl
>>> rng = np.random.RandomState(42)
>>> p1 = pcl.PointCloud(rng.randn(100000, 3).astype(np.float32))
>>> p2 = pcl.PointCloud(rng.randn(4000, 3).astype(np.float32))
>>> kd = pcl.KdTreeFLANN(p1)
>>> %timeit kd.nearest_k_search_for_cloud(p2)
100 loops, best of 3: 14.2 ms per loop
>>> %timeit kd.nearest_k_search_for_cloud(p2, 3)
100 loops, best of 3: 15.4 ms per loop
>>> %timeit kd.nearest_k_search_for_cloud(p2, 30)
10 loops, best of 3: 28.3 ms per loop
```

Previously:

``` python
>>> %timeit kd.nearest_k_search_for_cloud(p2)
10 loops, best of 3: 42.9 ms per loop
>>> %timeit kd.nearest_k_search_for_cloud(p2, 3)
10 loops, best of 3: 43.5 ms per loop
>>> %timeit kd.nearest_k_search_for_cloud(p2, 30)
10 loops, best of 3: 57.5 ms per loop
```
