### PR TITLE
Two bug fixes

### DIFF
--- a/pcl/_pcl.pyx
+++ b/pcl/_pcl.pyx
@@ -15,9 +15,13 @@ from libcpp cimport bool
 from libcpp.vector cimport vector
 
 cdef extern from "minipcl.h":
-    void mpcl_compute_normals(cpp.PointCloud_t, int ksearch, double searchRadius, cpp.PointNormalCloud_t)
-    void mpcl_sacnormal_set_axis(cpp.SACSegmentationNormal_t, double ax, double ay, double az)
-    void mpcl_extract(cpp.PointCloud_t, cpp.PointCloud_t, cpp.PointIndices_t *, bool)
+    void mpcl_compute_normals(cpp.PointCloud_t, int ksearch,
+                              double searchRadius,
+                              cpp.PointNormalCloud_t) except +
+    void mpcl_sacnormal_set_axis(cpp.SACSegmentationNormal_t,
+                                 double ax, double ay, double az) except +
+    void mpcl_extract(cpp.PointCloud_t, cpp.PointCloud_t, cpp.PointIndices_t *,
+                      bool) except +
 
 SAC_RANSAC = cpp.SAC_RANSAC
 SAC_LMEDS = cpp.SAC_LMEDS


### PR DESCRIPTION
Apparently the `__repr__` I pushed was the wrong version; currently python-pcl won't even build. This is the right one.

Also a patch for more exception-safety.
