### PR TITLE
Fix OS X build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test: pcl/_pcl.so tests/test.py
 
 clean:
 	rm -rf build
-	rm -f pcl/_pcl.cpp pcl/_pcl.so
+	rm -f pcl/_pcl.cpp pcl/_pcl.so pcl/registration.so
 
 doc: pcl.so conf.py readme.rst
 	sphinx-build -b singlehtml -d build/doctrees . build/html

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,11 @@ from distutils.extension import Extension
 import subprocess
 import numpy
 import sys
+import platform
+import os
+
+if platform.system() == "Darwin":
+	os.environ['ARCHFLAGS'] = ''
 
 # Try to find PCL. XXX we should only do this when trying to build or install.
 PCL_SUPPORTED = ["-1.7", "-1.6", ""]    # in order of preference


### PR DESCRIPTION
My colleague @blootsvoets fixed the build scripts to get python-pcl to work on a Mac.