### PR TITLE
Buffer api: easier NumPy interop

### DIFF
--- a/pcl/_pcl.pxd
+++ b/pcl/_pcl.pxd
@@ -7,6 +7,10 @@ cimport pcl_defs as cpp
 cdef class PointCloud:
     cdef cpp.PointCloudPtr_t thisptr_shared
 
+    # Buffer protocol support.
+    cdef Py_ssize_t _shape[2]
+    cdef Py_ssize_t _view_count
+
     cdef inline cpp.PointCloud[cpp.PointXYZ] *thisptr(self) nogil:
         # Shortcut to get raw pointer to underlying PointCloud<PointXYZ>.
         return self.thisptr_shared.get()

--- a/readme.rst
+++ b/readme.rst
@@ -29,7 +29,7 @@ point types
  * registration (ICP, GICP, ICP_NL)
 
 The code tries to follow the Point Cloud API, and also provides helper function
-for interacting with numpy. For example (from tests/test.py)
+for interacting with NumPy. For example (from tests/test.py)
 
 .. code-block:: python
 
@@ -52,6 +52,20 @@ or, for smoothing
     fil.set_std_dev_mul_thresh (1.0)
     fil.filter().to_file("inliers.pcd")
 
+Point clouds can be viewed as NumPy arrays, so modifying them is possible
+using all the familiar NumPy functionality:
+
+.. code-block:: python
+
+    import numpy as np
+    import pcl
+    p = pcl.PointCloud(10)  # "empty" point cloud
+    a = np.asarray(p)       # NumPy view on the cloud
+    a[:] = 0                # fill with zeros
+    print(p[3])             # prints (0.0, 0.0, 0.0)
+    a[:, 0] = 1             # set x coordinates to 1
+    print(p[3])             # prints (1.0, 0.0, 0.0)
+
 More samples can be found in the `examples directory <https://github.com/strawlab/python-pcl/tree/master/examples>`_,
 and in the `unit tests <https://github.com/strawlab/python-pcl/blob/master/tests/test.py>`_.
 
@@ -60,11 +74,11 @@ This work was supported by `Strawlab <http://strawlab.org/>`_.
 Requirements
 ------------
 
-This release has been tested on Ubuntu 13.10 with
+This release has been tested on Linux Mint 17 with
 
- * Python 2.7.5
- * pcl 1.7.1
- * Cython 0.21
+ * Python 2.7.6
+ * pcl 1.7.2
+ * Cython 0.21.2
 
 and CentOS 6.5 with
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -7,7 +7,7 @@ import unittest
 import pcl
 import numpy as np
 
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 
 _data = [(i,2*i,3*i+0.2) for i in range(5)]
@@ -38,7 +38,7 @@ class TestNumpyIO(unittest.TestCase):
         self.a = np.array(np.mat(_DATA, dtype=np.float32))
         self.p = pcl.PointCloud(self.a)
 
-    def testFromNumy(self):
+    def testFromNumpy(self):
         for i,d in enumerate(_data):
             pt = self.p[i]
             assert np.allclose(pt, _data[i])
@@ -46,6 +46,13 @@ class TestNumpyIO(unittest.TestCase):
     def testToNumpy(self):
         a = self.p.to_array()
         self.assertTrue(np.alltrue(a == self.a))
+
+    def test_asarray(self):
+        p = pcl.PointCloud(self.p)      # copy
+        old0 = p[0]
+        a = np.asarray(p)               # view
+        a[:] += 6
+        assert_array_almost_equal(p[0], a[0])
 
     def test_pickle(self):
         """Test pickle support."""


### PR DESCRIPTION
This allows memory sharing between PCL and NumPy.

Closes #49.