### PR TITLE
Fix bug in buffer protocol support

### DIFF
--- a/pcl/_pcl.pyx
+++ b/pcl/_pcl.pyx
@@ -129,7 +129,7 @@ cdef class SegmentationNormal:
         mpcl_sacnormal_set_axis(deref(self.me),ax,ay,az)
 
 
-# Empirically determine strides, for buffer support.
+# Empirically determine strides, for buffer protocol support.
 # XXX Is there a more elegant way to get these?
 cdef Py_ssize_t _strides[2]
 cdef PointCloud _pc_tmp = PointCloud(np.array([[1, 2, 3],
@@ -196,9 +196,9 @@ cdef class PointCloud:
         cdef Py_ssize_t npoints = self.thisptr().size()
 
         if self._view_count == 0:
-            self._view_count += 1
             self._shape[0] = npoints
             self._shape[1] = 3
+        self._view_count += 1
 
         buffer.buf = <char *>&(cpp.getptr_at(self.thisptr(), 0).x)
         buffer.format = 'f'

--- a/tests/test.py
+++ b/tests/test.py
@@ -53,6 +53,13 @@ class TestNumpyIO(unittest.TestCase):
         a[:] += 6
         assert_array_almost_equal(p[0], a[0])
 
+        # Regression test: deleting a second view would previously
+        # reset the view count to zero.
+        b = np.asarray(p)
+        del b
+
+        self.assertRaises(ValueError, p.resize, 2 * len(p))
+
     def test_pickle(self):
         """Test pickle support."""
         # In this testcase because picking reduces to pickling NumPy arrays.


### PR DESCRIPTION
The view count was not correctly incremented beyond 1, so having two views and releasing one would bring it back to 0.