### PR TITLE
[setup] fix c++ compil error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,8 @@ for flag in pkgconfig('--libs-only-other'):
 ext_args['define_macros'].append(
     ("EIGEN_YES_I_KNOW_SPARSE_MODULE_IS_NOT_STABLE_YET", "1"))
 
+ext_args['extra_compile_args'].append("-std=c++0x")
+
 setup(name='python-pcl',
       description='pcl wrapper',
       url='http://github.com/strawlab/python-pcl',


### PR DESCRIPTION
fix #80

when calling `python setup.py install --user`
on Ubuntu 14.04 [gcc 4.8.4 / cython 0.20.1post0]:
```
pcl/_pcl.cpp: In function ‘int __pyx_pf_3pcl_4_pcl_10PointCloud___cinit__(__pyx_obj_3pcl_4_pcl_PointCloud*, PyObject*)’:
pcl/_pcl.cpp:3831:49: error: ‘>>’ should be ‘> >’ within a nested template argument list
   sp_assign<pcl::PointCloud<struct pcl::PointXYZ>>(__pyx_v_self->thisptr_shared, __pyx_t_1);
                                                 ^
```