### PR TITLE
PointXYZI intensity casting

### DIFF
--- a/pcl/pxi/PointCloud_PointXYZI.pxi
+++ b/pcl/pxi/PointCloud_PointXYZI.pxi
@@ -155,7 +155,7 @@ cdef class PointCloud_PointXYZI:
         cdef cpp.PointXYZI *p
         for i in range(npts):
             p = idx.getptr(self.thisptr(), i)
-            p.x, p.y, p.z, p.intensity = arr[i, 0], arr[i, 1], arr[i, 2], <unsigned long>arr[i, 3]
+            p.x, p.y, p.z, p.intensity = arr[i, 0], arr[i, 1], arr[i, 2], arr[i, 3]
 
     @cython.boundscheck(False)
     def to_array(self):

--- a/pcl/pxi/PointCloud_PointXYZI_172.pxi
+++ b/pcl/pxi/PointCloud_PointXYZI_172.pxi
@@ -151,7 +151,7 @@ cdef class PointCloud_PointXYZI:
         cdef cpp.PointXYZI *p
         for i in range(npts):
             p = idx.getptr(self.thisptr(), i)
-            p.x, p.y, p.z, p.intensity = arr[i, 0], arr[i, 1], arr[i, 2], <unsigned long>arr[i, 3]
+            p.x, p.y, p.z, p.intensity = arr[i, 0], arr[i, 1], arr[i, 2], arr[i, 3]
 
     @cython.boundscheck(False)
     def to_array(self):

--- a/pcl/pxi/PointCloud_PointXYZI_180.pxi
+++ b/pcl/pxi/PointCloud_PointXYZI_180.pxi
@@ -151,7 +151,7 @@ cdef class PointCloud_PointXYZI:
         cdef cpp.PointXYZI *p
         for i in range(npts):
             p = idx.getptr(self.thisptr(), i)
-            p.x, p.y, p.z, p.intensity = arr[i, 0], arr[i, 1], arr[i, 2], <unsigned long>arr[i, 3]
+            p.x, p.y, p.z, p.intensity = arr[i, 0], arr[i, 1], arr[i, 2], arr[i, 3]
 
     @cython.boundscheck(False)
     def to_array(self):


### PR DESCRIPTION
In `from_array` for `PointXYZI`, the intensity is cast to integer, while the underlying type is float, so in fact float intensity is not supported. For explicit integer type support (labels) there is pcl::PointXYZL.