### PR TITLE
Add compute() on MomentOfInertiaEstimation

### DIFF
--- a/pcl/pxi/Features/MomentOfInertiaEstimation_172.pxi
+++ b/pcl/pxi/Features/MomentOfInertiaEstimation_172.pxi
@@ -29,6 +29,7 @@ cdef class MomentOfInertiaEstimation:
     def __dealloc__(self):
         del self.me
 
+    # feature_extractor.compute ();
     # feature_extractor.getMomentOfInertia (moment_of_inertia);
     # feature_extractor.getEccentricity (eccentricity);
     # feature_extractor.getAABB (min_point_AABB, max_point_AABB);
@@ -36,6 +37,9 @@ cdef class MomentOfInertiaEstimation:
     # feature_extractor.getEigenValues (major_value, middle_value, minor_value);
     # feature_extractor.getEigenVectors (major_vector, middle_vector, minor_vector);
     # feature_extractor.getMassCenter (mass_center);
+    def compute (self):
+        self.me.compute()
+
     def get_MomentOfInertia (self):
         cdef vector[float] moment_of_inertia
         self.me.getMomentOfInertia(moment_of_inertia)

--- a/pcl/pxi/Features/MomentOfInertiaEstimation_180.pxi
+++ b/pcl/pxi/Features/MomentOfInertiaEstimation_180.pxi
@@ -29,6 +29,7 @@ cdef class MomentOfInertiaEstimation:
     def __dealloc__(self):
         del self.me
 
+    # feature_extractor.compute ();
     # feature_extractor.getMomentOfInertia (moment_of_inertia);
     # feature_extractor.getEccentricity (eccentricity);
     # feature_extractor.getAABB (min_point_AABB, max_point_AABB);
@@ -36,6 +37,9 @@ cdef class MomentOfInertiaEstimation:
     # feature_extractor.getEigenValues (major_value, middle_value, minor_value);
     # feature_extractor.getEigenVectors (major_vector, middle_vector, minor_vector);
     # feature_extractor.getMassCenter (mass_center);
+    def compute (self):
+        self.me.compute()
+
     def get_MomentOfInertia (self):
         cdef vector[float] moment_of_inertia
         self.me.getMomentOfInertia(moment_of_inertia)


### PR DESCRIPTION
`MomentOfInertiaEstimation` class misses binding for `compute()`, without calling it all methods of estimator return empty results.