### PR TITLE
appveyor generates python wheels with pcl dlls included for windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -131,5 +131,15 @@ test_script:
   # - python examples\official\Segmentation\cylinder_segmentation.py
   # - python examples\official\surface\concave_hull_2d.py
   # - python examples\official\surface\resampling.py
+  
+after_test:
+  # If tests are successful, create binary packages for the project.
+  - "%CMD_IN_ENV% python setup.py bdist_wheel"
+  - "%CMD_IN_ENV% python setup.py bdist_wininst"
+  - "%CMD_IN_ENV% python setup.py bdist_msi"
+  - ps: "ls dist"
 
+artifacts:
+  # Archive the generated packages in the ci.appveyor.com build report.
+- path: dist\*
 

--- a/examples/3dharris.py
+++ b/examples/3dharris.py
@@ -8,7 +8,7 @@ import pcl.pcl_visualization
 # pcl::io::loadPCDFile<pcl::PointXYZ> (argv[1], *cloud);
 # cloud = pcl.load("table_scene_mug_stereo_textured.pcd")
 # cloud = pcl.load('./examples/pcldata/tutorials/table_scene_mug_stereo_textured.pcd')
-cloud = pcl.load('./bunny.pcd')
+cloud = pcl.load('./tests/tutorials/bunny.pcd')
 print("cloud points : " + str(cloud.size))
 
 # pcl::HarrisKeypoint3D<pcl::PointXYZ, pcl::PointXYZI> detector;

--- a/examples/crophull.py
+++ b/examples/crophull.py
@@ -5,7 +5,7 @@ import numpy as np
 import pcl
 
 # http://www.pcl-users.org/CropHull-filter-question-td4030345.html
-datacloud = pcl.load('/examples/pcldata/tutorials/table_scene_mug_stereo_textured.pcd')
+datacloud = pcl.load('./examples/pcldata/tutorials/table_scene_mug_stereo_textured.pcd')
 
 print(datacloud)
 

--- a/examples/segment_cyl_plane.py
+++ b/examples/segment_cyl_plane.py
@@ -6,7 +6,7 @@
 
 import pcl
 
-cloud = pcl.load('table_scene_mug_stereo_textured.pcd')
+cloud = pcl.load('./examples/pcldata/tutorials/table_scene_mug_stereo_textured.pcd')
 
 print(cloud.size)
 

--- a/examples/sift.py
+++ b/examples/sift.py
@@ -73,7 +73,7 @@ def Extract_SIFT(cloud, cloud_normals):
 # pcl::io::loadPCDFile<pcl::PointXYZ> (argv[1], *cloud);
 # cloud = pcl.load("table_scene_mug_stereo_textured.pcd")
 # cloud = pcl.load('./examples/pcldata/tutorials/table_scene_mug_stereo_textured.pcd')
-cloud = pcl.load('./bunny.pcd')
+cloud = pcl.load('./tests/tutorials/bunny.pcd')
 print("cloud points : " + str(cloud.size))
 
 # pcl::PointCloud<pcl::PointNormal>::Ptr cloud_normals (new pcl::PointCloud<pcl::PointNormal>);

--- a/examples/statistical_outlier_fiter.py
+++ b/examples/statistical_outlier_fiter.py
@@ -5,13 +5,15 @@
 # http://svn.pointclouds.org/data/tutorials/table_scene_lms400.pcd
 
 import pcl
-p = pcl.load("table_scene_lms400.pcd")
+
+
+p = pcl.load("./examples/pcldata/tutorials/table_scene_lms400.pcd")
 
 fil = p.make_statistical_outlier_filter()
 fil.set_mean_k(50)
 fil.set_std_dev_mul_thresh(1.0)
 
-pcl.save(fil.filter(), "table_scene_lms400_inliers.pcd")
+pcl.save(fil.filter(), "./examples/pcldata/tutorials/table_scene_lms400_inliers.pcd")
 
 fil.set_negative(True)
-pcl.save(fil.filter(), "table_scene_lms400_outliers.pcd")
+pcl.save(fil.filter(), "./examples/pcldata/tutorials/table_scene_lms400_outliers.pcd")

--- a/pcl/__init__.py
+++ b/pcl/__init__.py
@@ -1,4 +1,32 @@
 # XXX do a more specific import!
+
+from ctypes.util import find_library
+
+list_PCL_Dlls='''pcl_common_release
+pcl_features_release
+pcl_filters_release
+pcl_io_ply_release
+pcl_io_release
+pcl_kdtree_release
+pcl_keypoints_release
+pcl_ml_release
+pcl_octree_release
+pcl_outofcore_release
+pcl_people_release
+pcl_recognition_release
+pcl_registration_release
+pcl_sample_consensus_release
+pcl_search_release
+pcl_segmentation_release
+pcl_stereo_release
+pcl_surface_release
+pcl_tracking_release
+pcl_visualization_release'''.split('\n')
+
+for dll in list_PCL_Dlls:
+	if find_library(dll) is None:
+		raise(Exception('Could not find the PCL binary %s on the path, make sure you installed the C++ PCL library and added the bin folder to the path'%dll))
+
 from ._pcl import *
 # vtkSmartPointer.h error (Linux)
 # from .pcl_visualization import *

--- a/pcl/__init__.py
+++ b/pcl/__init__.py
@@ -2,31 +2,6 @@
 
 from ctypes.util import find_library
 
-list_PCL_Dlls='''pcl_common_release
-pcl_features_release
-pcl_filters_release
-pcl_io_ply_release
-pcl_io_release
-pcl_kdtree_release
-pcl_keypoints_release
-pcl_ml_release
-pcl_octree_release
-pcl_outofcore_release
-pcl_people_release
-pcl_recognition_release
-pcl_registration_release
-pcl_sample_consensus_release
-pcl_search_release
-pcl_segmentation_release
-pcl_stereo_release
-pcl_surface_release
-pcl_tracking_release
-pcl_visualization_release'''.split('\n')
-
-for dll in list_PCL_Dlls:
-	if find_library(dll) is None:
-		raise(Exception('Could not find the PCL binary %s on the path, make sure you installed the C++ PCL library and added the bin folder to the path'%dll))
-
 from ._pcl import *
 # vtkSmartPointer.h error (Linux)
 # from .pcl_visualization import *

--- a/readme.rst
+++ b/readme.rst
@@ -187,8 +187,25 @@ circumvent:
 Windows
 -------
 
-before Install module
+Using precompiled wheel
 ^^^^^^^^^^^^^^^^^^^^^
+
+	This is the simpliest method on windows. The wheel contains the PCL binaries and thus you do not need to install the original PCL library.
+
+	1. Click on the job corresponding to your python version on the [(appveyor page)https://ci.appveyor.com/project/Sirokujira/python-pcl-iju42] 
+	2. Go in the artfacts section for that job and download the whell (whl file)
+	3. In the command line, move to your download folder and run the command (replacing XXX by the right string)	
+		
+		pip install python_pcl-XXX.whl
+	
+		
+Compiling the binding from source
+^^^^^^^^^^^^^^^^^^^^^		
+
+	If the method using the procompiled wheel does not work you can compile the binding from the source.
+	
+before Install module
+~~~~~~~~~~~~~~~~~~~
 
         Case1. use PCL 1.6.0 
 
@@ -225,7 +242,7 @@ before Install module
 `Python Version use VisualStudio Compiler <https://wiki.python.org/moin/WindowsCompilers>`_ 
 
 set before Environment variable
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~
     
     1. PCL_ROOT
 

--- a/readme.rst
+++ b/readme.rst
@@ -192,7 +192,7 @@ Using precompiled wheel
 
 	This is the simpliest method on windows. The wheel contains the PCL binaries and thus you do not need to install the original PCL library.
 
-	1. Click on the job corresponding to your python version on the [(appveyor page)https://ci.appveyor.com/project/Sirokujira/python-pcl-iju42] 
+	1. Click on the job corresponding to your python version on the `appveyor page <https://ci.appveyor.com/project/Sirokujira/python-pcl-iju42> `
 	2. Go in the artfacts section for that job and download the whell (whl file)
 	3. In the command line, move to your download folder and run the command (replacing XXX by the right string)	
 		

--- a/readme.rst
+++ b/readme.rst
@@ -187,16 +187,19 @@ circumvent:
 Windows
 -------
 
-Using precompiled wheel
+Using pip with a precompiled wheel
 ^^^^^^^^^^^^^^^^^^^^^
 
 	This is the simpliest method on windows. The wheel contains the PCL binaries and thus you do not need to install the original PCL library.
+	
+	1. Go in the history on the `appveyor page <https://ci.appveyor.com/project/Sirokujira/python-pcl-iju42/history>`_
+	2. Click on the last successful revision (green) and click on the job corresponding to your python version 
+	3. Go in the artfacts section for that job and download the wheel (the file with extension whl)
+	4. In the command line, move to your download folder and run the following command (replacing XXX by the right string)	
+	
+.. code-block:: none
 
-	1. Click on the job corresponding to your python version on the `appveyor page <https://ci.appveyor.com/project/Sirokujira/python-pcl-iju42> `
-	2. Go in the artfacts section for that job and download the whell (whl file)
-	3. In the command line, move to your download folder and run the command (replacing XXX by the right string)	
-		
-		pip install python_pcl-XXX.whl
+			pip install python_pcl-XXX.whl
 	
 		
 Compiling the binding from source

--- a/readme.rst
+++ b/readme.rst
@@ -188,7 +188,7 @@ Windows
 -------
 
 Using pip with a precompiled wheel
-^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 	This is the simpliest method on windows. The wheel contains the PCL binaries and thus you do not need to install the original PCL library.
 	
@@ -203,12 +203,12 @@ Using pip with a precompiled wheel
 	
 		
 Compiling the binding from source
-^^^^^^^^^^^^^^^^^^^^^		
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^		
 
 	If the method using the procompiled wheel does not work you can compile the binding from the source.
 	
 before Install module
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
         Case1. use PCL 1.6.0 
 
@@ -245,7 +245,7 @@ before Install module
 `Python Version use VisualStudio Compiler <https://wiki.python.org/moin/WindowsCompilers>`_ 
 
 set before Environment variable
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     
     1. PCL_ROOT
 

--- a/setup.py
+++ b/setup.py
@@ -503,6 +503,18 @@ if platform.system() == "Windows":
     else:
         print('no pcl install or pkg-config missed.')
         sys.exit(1)
+	
+    # copy the pcl dll to local subfolder so that it can be added to the package through the data_files option
+    listDlls=[]
+    if not os.path.isdir('./dlls'):
+	os.mkdir('./dlls')
+    for dll in libreleases:
+	pathDll=find_library(dll)
+	if not pathDll is None:
+	    shutil.copy2(pathDll, './dlls' )
+	    listDlls.append(os.path.join('.\\dlls',dll+'.dll'))
+    data_files=[('Lib/site-packages/pcl',listDlls)]# the path is relative to the python root folder 
+    
 else:
     # Not 'Windows'
     if platform.system() == "Darwin":
@@ -624,26 +636,11 @@ else:
     else:
         print('no pcl install or pkg-config missed.')
         sys.exit(1)
+	
+    listDlls=[]
+    data_files=None			
 		
-		
-
-
-		
-if platform.system() == "Windows":	
-	# copy the pcl dll to local ubfolder so that it can be added to the package through the data_files option
-	listDlls=[]
-	if not os.path.isdir('./dlls'):
-		os.mkdir('./dlls')
-	for dll in libreleases:
-		pathDll=find_library(dll)
-		if not pathDll is None:
-			shutil.copy2(pathDll, './dlls' )
-			listDlls.append(os.path.join('.\\dlls',dll+'.dll'))
-	data_files=[('Lib/site-packages/pcl',listDlls)]# the path is relative to the python root folder
-else:
-	listDlls=[]
-	data_files=None	
-
+  
 		
 setup(name='python-pcl',
       description='pcl wrapper',

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ import os
 import time
 
 import shutil
+from ctypes.util import find_library
 setup_requires = []
 install_requires = [
     'filelock',
@@ -636,6 +637,19 @@ for dll in libreleases:
 		shutil.copy2(pathDll, './dlls' )
 		listDlls.append(os.path.join('.\\dlls',dll+'.dll'))
 		
+if platform.system() == "Windows":	
+	listDlls=[]
+	if not os.path.isdir('./dlls'):
+		os.mkdir('./dlls')
+	for dll in libreleases:
+		pathDll=find_library(dll)
+		if not pathDll is None:
+			shutil.copy2(pathDll, './dlls' )
+			listDlls.append(os.path.join('.\\dlls',dll+'.dll'))
+	data_files=[('Lib/site-packages/pcl',listDlls)]# the path is relative to the python root folder
+else:
+	listDlls=[]
+	data_files=None	
 
 		
 setup(name='python-pcl',
@@ -661,5 +675,5 @@ setup(name='python-pcl',
       tests_require=['mock', 'nose'],
       ext_modules=module,
       cmdclass={'build_ext': build_ext},
-	  data_files=[('pcl',listDlls)]
+	  data_files=data_files
 )

--- a/setup.py
+++ b/setup.py
@@ -626,18 +626,11 @@ else:
         sys.exit(1)
 		
 		
-# copy the pcl dll to local ubfolder so that it can be added to the package through the data_files option
-from ctypes.util import find_library
-listDlls=[]
-if not os.path.isdir('./dlls'):
-	os.mkdir('./dlls')
-for dll in libreleases:
-	pathDll=find_library(dll)
-	if not pathDll is None:
-		shutil.copy2(pathDll, './dlls' )
-		listDlls.append(os.path.join('.\\dlls',dll+'.dll'))
+
+
 		
 if platform.system() == "Windows":	
+	# copy the pcl dll to local ubfolder so that it can be added to the package through the data_files option
 	listDlls=[]
 	if not os.path.isdir('./dlls'):
 		os.mkdir('./dlls')

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if platform.system() == "Windows":
     # Check 32bit or 64bit
     is_64bits = sys.maxsize > 2**32
     # if is_64bits == True
-    
+
     # environment Value
     for k, v in os.environ.items():
         # print("{key} : {value}".format(key=k, value=v))
@@ -137,7 +137,7 @@ if platform.system() == "Windows":
     # get pkg-config.exe filePath
     pkgconfigPath = os.getcwd() + '\\pkg-config\\pkg-config.exe'
     print(pkgconfigPath)
-    
+
     # AppVeyor Check
     for k, v in os.environ.items():
         # print("{key} : {value}".format(key=k, value=v))
@@ -147,7 +147,7 @@ if platform.system() == "Windows":
     else:
         # Try to find PCL. XXX we should only do this when trying to build or install.
         PCL_SUPPORTED = ["-1.8", "-1.7", "-1.6", ""]    # in order of preference
-        
+
         for pcl_version in PCL_SUPPORTED:
             if subprocess.call(['.\\pkg-config\\pkg-config.exe', 'pcl_common%s' % pcl_version]) == 0:
             # if subprocess.call([pkgconfigPath, 'pcl_common%s' % pcl_version]) == 0:
@@ -158,13 +158,13 @@ if platform.system() == "Windows":
             for version in PCL_SUPPORTED:
                 print('    pkg-config pcl_common%s' % version, file=sys.stderr)
             sys.exit(1)
-    
+
     print(pcl_version)
     # pcl_version = '-1.6'
-    
+
     # Python Version Check
     info = sys.version_info
-    
+
     if pcl_version == '-1.6':
         # PCL 1.6.0 python Version == 3.4(>= 3.4?, 2.7 -> NG)
         # Visual Studio 2010
@@ -188,7 +188,7 @@ if platform.system() == "Windows":
             # pcl-1.8
             # 1.8.1 use 2d required features
             pcl_libs = ["2d", "common", "features", "filters", "geometry",
-                    "io", "kdtree", "keypoints", "ml", "octree", "outofcore", "people",
+                        "io", "kdtree", "keypoints", "ml", "octree", "outofcore", "people",
                     "recognition", "registration", "sample_consensus", "search",
                     "segmentation", "stereo", "surface", "tracking", "visualization"]
         else:
@@ -204,7 +204,7 @@ if platform.system() == "Windows":
             # pcl-1.8
             # 1.8.1 use 2d required features
             pcl_libs = ["2d", "common", "features", "filters", "geometry",
-                    "io", "kdtree", "keypoints", "ml", "octree", "outofcore", "people",
+                        "io", "kdtree", "keypoints", "ml", "octree", "outofcore", "people",
                     "recognition", "registration", "sample_consensus", "search",
                     "segmentation", "stereo", "surface", "tracking", "visualization"]
             pass
@@ -214,17 +214,17 @@ if platform.system() == "Windows":
     else:
         print('pcl_version Unknown')
         sys.exit(1)
-    
+
     # Find build/link options for PCL using pkg-config.
-    
+
     pcl_libs = ["pcl_%s%s" % (lib, pcl_version) for lib in pcl_libs]
     # pcl_libs += ['Eigen3']
     # print(pcl_libs)
-    
+
     ext_args = defaultdict(list)
     # set include path
     ext_args['include_dirs'].append(numpy.get_include())
-    
+
     # Get setting pkg-config
     # add include headers
     # use pkg-config
@@ -233,7 +233,7 @@ if platform.system() == "Windows":
     #     print(flag.lstrip().rstrip())
     # print('test')
     #     ext_args['include_dirs'].append(flag.lstrip().rstrip())
-    
+
     # no use pkg-config
     if pcl_version == '-1.6':
         # 1.6.0
@@ -259,10 +259,10 @@ if platform.system() == "Windows":
         inc_dirs = [pcl_root + '\\include\\pcl' + pcl_version, pcl_root + '\\3rdParty\\\Eigen\\eigen3', pcl_root + '\\3rdParty\\Boost\\include\\boost-' + boost_version, pcl_root + '\\3rdParty\\FLANN\\include', pcl_root + '\\3rdParty\\VTK\\include\\vtk-' + vtk_version]
     else:
         inc_dirs = []
-    
+
     for inc_dir in inc_dirs:
         ext_args['include_dirs'].append(inc_dir)
-    
+
     # for flag in pkgconfig_win('--libs-only-L', '-L'):
     #     print(flag.lstrip().rstrip())
     #     ext_args['library_dirs'].append(flag[2:])
@@ -271,7 +271,7 @@ if platform.system() == "Windows":
     #     print(flag.lstrip().rstrip())
     #     ext_args['extra_link_args'].append(flag)
     # end
-    
+
     # set library path
     if pcl_version == '-1.6':
         # 3rdParty(+Boost, +VTK)
@@ -287,13 +287,13 @@ if platform.system() == "Windows":
         lib_dirs = [pcl_root + '\\lib', pcl_root + '\\3rdParty\\Boost\\lib', pcl_root + '\\3rdParty\\FLANN\\lib', pcl_root + '\\3rdParty\\VTK\lib']
     else:
         lib_dir = []
-    
+
     for lib_dir in lib_dirs:
         ext_args['library_dirs'].append(lib_dir)
-    
+
     # OpenNI2?
     # %OPENNI2_REDIST64% %OPENNI2_REDIST%
-    
+
     # set compiler flags
     # for flag in pkgconfig_win('--cflags-only-other'):
     #     if flag.startswith('-D'):
@@ -307,13 +307,13 @@ if platform.system() == "Windows":
     #         print("skipping -lflann_cpp-gd (see https://github.com/strawlab/python-pcl/issues/29")
     #         continue
     #     ext_args['libraries'].append(flag.lstrip().rstrip())
-    
+
     if pcl_version == '-1.6':
         # release
         # libreleases = ['pcl_apps_release', 'pcl_common_release', 'pcl_features_release', 'pcl_filters_release', 'pcl_io_release', 'pcl_io_ply_release', 'pcl_kdtree_release', 'pcl_keypoints_release', 'pcl_octree_release', 'pcl_registration_release', 'pcl_sample_consensus_release', 'pcl_segmentation_release', 'pcl_search_release', 'pcl_surface_release', 'pcl_tracking_release', 'pcl_visualization_release', 'flann', 'flann_s']
         # release + vtk
         libreleases = ['pcl_apps_release', 'pcl_common_release', 'pcl_features_release', 'pcl_filters_release', 'pcl_io_release', 'pcl_io_ply_release', 'pcl_kdtree_release', 'pcl_keypoints_release', 'pcl_octree_release', 'pcl_registration_release', 'pcl_sample_consensus_release', 'pcl_segmentation_release', 'pcl_search_release', 'pcl_surface_release', 'pcl_tracking_release', 'pcl_visualization_release', 'flann', 'flann_s', 'vtkInfovis', 'MapReduceMPI', 'vtkNetCDF', 'QVTK', 'vtkNetCDF_cxx', 'vtkRendering', 'vtkViews', 'vtkVolumeRendering', 'vtkWidgets', 'mpistubs', 'vtkalglib', 'vtkCharts', 'vtkexoIIc', 'vtkexpat', 'vtkCommon', 'vtkfreetype', 'vtkDICOMParser', 'vtkftgl', 'vtkFiltering', 'vtkhdf5', 'vtkjpeg', 'vtkGenericFiltering', 'vtklibxml2', 'vtkGeovis', 'vtkmetaio', 'vtkpng', 'vtkGraphics', 'vtkproj4', 'vtkHybrid', 'vtksqlite', 'vtksys', 'vtkIO', 'vtktiff', 'vtkImaging', 'vtkverdict', 'vtkzlib']
-        
+
         # add boost
         # dynamic lib
         # libreleases = ['pcl_apps_release', 'pcl_common_release', 'pcl_features_release', 'pcl_filters_release', 'pcl_io_release', 'pcl_io_ply_release', 'pcl_kdtree_release', 'pcl_keypoints_release', 'pcl_octree_release', 'pcl_registration_release', 'pcl_sample_consensus_release', 'pcl_segmentation_release', 'pcl_search_release', 'pcl_surface_release', 'pcl_tracking_release', 'pcl_visualization_release', 'flann', 'flann_s', 'boost_date_time-vc100-mt-1_47', 'boost_filesystem-vc100-mt-1_49', 'boost_graph-vc100-mt-1_49', 'boost_graph_parallel-vc100-mt-1_49', 'boost_iostreams-vc100-mt-1_49', 'boost_locale-vc100-mt-1_49', 'boost_math_c99-vc100-mt-1_49', 'boost_math_c99f-vc100-mt-1_49', 'boost_math_tr1-vc100-mt-1_49', 'boost_math_tr1f-vc100-mt-1_49', 'boost_mpi-vc100-mt-1_49', 'boost_prg_exec_monitor-vc100-mt-1_49', 'boost_program_options-vc100-mt-1_49', 'boost_random-vc100-mt-1_49', 'boost_regex-vc100-mt-1_49', 'boost_serialization-vc100-mt-1_49', 'boost_signals-vc100-mt-1_49', 'boost_system-vc100-mt-1_49', 'boost_thread-vc100-mt-1_49', 'boost_timer-vc100-mt-1_49', 'boost_unit_test_framework-vc100-mt-1_49', 'boost_wave-vc100-mt-1_49', 'boost_wserialization-vc100-mt-1_49']
@@ -364,7 +364,7 @@ if platform.system() == "Windows":
     # http://stackoverflow.com/questions/1236670/how-to-make-opengl-apps-in-64-bits-windows
     # C:\Program Files (x86)\Microsoft SDKs\Windows\7.0\Lib\x64\OpenGL32.lib
     # C:\Program Files (x86)\Microsoft SDKs\Windows\v7.0A\Lib\x64\OpenGL32.lib
-    
+
     # Add OpenGL32 .h/.lib
     win_kit_incs = []
     win_kit_libdirs = []
@@ -390,7 +390,7 @@ if platform.system() == "Windows":
             # win_kit_incs = ['C:\\Program Files (x86)\\Windows Kits\\8.1\\Include\\shared', 'C:\\Program Files (x86)\\Windows Kits\\8.1\\Include\\um']
             # win_kit_libdirs = ['C:\\Program Files (x86)\\Windows Kits\\8.1\\Lib\\winv6.3\\um\\x64']
             # win_kit_libdirs = ['C:\\Program Files (x86)\\Windows Kits\\10\\Lib\\10.0.10240.0\\ucrt\\x64']
-            
+
             # Windows OS 8/8.1/10?
             # win_kit_incs = ['C:\\Program Files (x86)\\Windows Kits\\10\\Include\\10.0.10240.0\\ucrt']
             # win_kit_incs = ['C:\\Program Files (x86)\\Windows Kits\\10\\Include\\shared']
@@ -404,21 +404,21 @@ if platform.system() == "Windows":
             pass
     else:
         pass
-    
+
     for inc_dir in win_kit_incs:
         ext_args['include_dirs'].append(inc_dir)
 
     for lib_dir in win_kit_libdirs:
         ext_args['library_dirs'].append(lib_dir)
-    
+
     win_opengl_libreleases = ['OpenGL32']
     for opengl_librelease in win_opengl_libreleases:
         ext_args['libraries'].append(opengl_librelease)
-    
+
     # use OpenNI
     # use OpenNI2
     # add environment PATH : pcl/bin, OpenNI2/Tools
-    
+
     # use CUDA?
     # CUDA_PATH
     # CUDA_PATH_V7_5
@@ -431,7 +431,7 @@ if platform.system() == "Windows":
     else:
         print('No use cuda.')
         pass
-    
+
     # ext_args['define_macros'].append(('EIGEN_YES_I_KNOW_SPARSE_MODULE_IS_NOT_STABLE_YET', '1'))
     # define_macros=[('BOOST_NO_EXCEPTIONS', 'None')],
     # debugs = [('EIGEN_YES_I_KNOW_SPARSE_MODULE_IS_NOT_STABLE_YET', '1'), ('BOOST_NO_EXCEPTIONS', 'None')]
@@ -440,7 +440,7 @@ if platform.system() == "Windows":
                 '1'), ('_CRT_SECURE_NO_WARNINGS', '1')]
     for define in defines:
         ext_args['define_macros'].append(define)
-    
+
     # ext_args['extra_compile_args'].append('/DWIN32')
     # ext_args['extra_compile_args'].append('/D_WINDOWS')
     # ext_args['extra_compile_args'].append('/W3')
@@ -453,7 +453,7 @@ if platform.system() == "Windows":
     # https://ci.appveyor.com/project/KazuakiM/vim-ms-translator/branch/master 
     # ext_args['extra_compile_args'].append('/DDYNAMIC_MSVCRT_DLL=\"msvcr100.dll\"')
     # ext_args['extra_compile_args'].append('/DDYNAMIC_MSVCRT_DLL=\"msvcr100.dll\"')
-    
+
     # NG
     # ext_args['extra_compile_args'].append('/NODEFAULTLIB:msvcrtd')
     # https://blogs.msdn.microsoft.com/vcblog/2015/03/03/introducing-the-universal-crt/
@@ -479,7 +479,7 @@ if platform.system() == "Windows":
     if pcl_version == '-1.6':
         module = [Extension("pcl._pcl", ["pcl/_pcl.pyx", "pcl/minipcl.cpp", "pcl/ProjectInliers.cpp"], language="c++", **ext_args),
                   Extension("pcl.pcl_visualization", [
-                            "pcl/pcl_visualization.pyx"], language="c++", **ext_args),
+                      "pcl/pcl_visualization.pyx"], language="c++", **ext_args),
                   # Extension("pcl.pcl_grabber", ["pcl/pcl_grabber.pyx", "pcl/grabber_callback.cpp"], language="c++", **ext_args),
                   # debug
                   # gdb_debug=True,
@@ -487,7 +487,7 @@ if platform.system() == "Windows":
     elif pcl_version == '-1.7':
         module = [Extension("pcl._pcl", ["pcl/_pcl_172.pyx", "pcl/minipcl.cpp", "pcl/ProjectInliers.cpp"], language="c++", **ext_args),
                   Extension("pcl.pcl_visualization", [
-                            "pcl/pcl_visualization.pyx"], language="c++", **ext_args),
+                      "pcl/pcl_visualization.pyx"], language="c++", **ext_args),
                   # Extension("pcl.pcl_grabber", ["pcl/pcl_grabber.pyx", "pcl/grabber_callback.cpp"], language="c++", **ext_args),
                   # debug
                   # gdb_debug=True,
@@ -495,7 +495,7 @@ if platform.system() == "Windows":
     elif pcl_version == '-1.8':
         module = [Extension("pcl._pcl", ["pcl/_pcl_180.pyx", "pcl/minipcl.cpp", "pcl/ProjectInliers.cpp"], language="c++", **ext_args),
                   Extension("pcl.pcl_visualization", [
-                            "pcl/pcl_visualization.pyx"], language="c++", **ext_args),
+                      "pcl/pcl_visualization.pyx"], language="c++", **ext_args),
                   # Extension("pcl.pcl_grabber", ["pcl/pcl_grabber.pyx", "pcl/grabber_callback.cpp"], language="c++", **ext_args),
                   # debug
                   # gdb_debug=True,
@@ -503,18 +503,18 @@ if platform.system() == "Windows":
     else:
         print('no pcl install or pkg-config missed.')
         sys.exit(1)
-	
+
     # copy the pcl dll to local subfolder so that it can be added to the package through the data_files option
     listDlls=[]
     if not os.path.isdir('./dlls'):
-	os.mkdir('./dlls')
+        os.mkdir('./dlls')
     for dll in libreleases:
-	pathDll=find_library(dll)
-	if not pathDll is None:
-	    shutil.copy2(pathDll, './dlls' )
-	    listDlls.append(os.path.join('.\\dlls',dll+'.dll'))
+        pathDll=find_library(dll)
+        if not pathDll is None:
+            shutil.copy2(pathDll, './dlls' )
+            listDlls.append(os.path.join('.\\dlls',dll+'.dll'))
     data_files=[('Lib/site-packages/pcl',listDlls)]# the path is relative to the python root folder 
-    
+
 else:
     # Not 'Windows'
     if platform.system() == "Darwin":
@@ -552,7 +552,7 @@ else:
     ext_args['include_dirs'].append('/usr/include/ni')
     # ext_args['library_dirs'].append()
     # ext_args['libraries'].append()
-    
+
     # VTK use?
     # ext_args['include_dirs'].append('/usr/include/vtk')
     # ext_args['include_dirs'].append('/usr/local/include/vtk')
@@ -573,7 +573,7 @@ else:
             ext_args['define_macros'].append((macro, value))
         else:
             ext_args['extra_compile_args'].append(flag)
-    
+
     # clang?
     # https://github.com/strawlab/python-pcl/issues/129
     # gcc base libc++, clang base libstdc++
@@ -636,12 +636,12 @@ else:
     else:
         print('no pcl install or pkg-config missed.')
         sys.exit(1)
-	
+
     listDlls=[]
     data_files=None			
-		
-  
-		
+
+
+
 setup(name='python-pcl',
       description='pcl wrapper',
       url='http://github.com/strawlab/python-pcl',
@@ -652,18 +652,18 @@ setup(name='python-pcl',
       maintainer_email='t753github@gmail.com',
       license='BSD',
       packages=[
-                "pcl",
+          "pcl",
                 # "pcl.pcl_visualization",
-      ],
+                ],
       zip_safe=False,
       setup_requires=setup_requires,
       install_requires=install_requires,
       classifiers=[
-        'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
-      ],
+        ],
       tests_require=['mock', 'nose'],
       ext_modules=module,
       cmdclass={'build_ext': build_ext},
-	  data_files=data_files
+      data_files=data_files
 )

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ import platform
 import os
 import time
 
+import shutil
 setup_requires = []
 install_requires = [
     'filelock',
@@ -622,8 +623,21 @@ else:
     else:
         print('no pcl install or pkg-config missed.')
         sys.exit(1)
+		
+		
+# copy the pcl dll to local ubfolder so that it can be added to the package through the data_files option
+from ctypes.util import find_library
+listDlls=[]
+if not os.path.isdir('./dlls'):
+	os.mkdir('./dlls')
+for dll in libreleases:
+	pathDll=find_library(dll)
+	if not pathDll is None:
+		shutil.copy2(pathDll, './dlls' )
+		listDlls.append(os.path.join('.\\dlls',dll+'.dll'))
+		
 
-
+		
 setup(name='python-pcl',
       description='pcl wrapper',
       url='http://github.com/strawlab/python-pcl',
@@ -647,4 +661,5 @@ setup(name='python-pcl',
       tests_require=['mock', 'nose'],
       ext_modules=module,
       cmdclass={'build_ext': build_ext},
+	  data_files=[('pcl',listDlls)]
 )


### PR DESCRIPTION
keeping a copy of  the generated wheel in the appveyor's artefacts. This will ease the installation in windows, using the wheel instead of installing the windows toolkits etc. the wheel for windows for python 3.6 is available here https://ci.appveyor.com/project/martinResearch/python-pcl/build/job/94euli1pm58nfdox/artifacts