### PR TITLE
Match voxel filter type for XYZRGBA point clouds

### DIFF
--- a/pcl/pxi/PointCloud_PointXYZRGBA.pxi
+++ b/pcl/pxi/PointCloud_PointXYZRGBA.pxi
@@ -313,7 +313,7 @@ cdef class PointCloud_PointXYZRGBA:
         """
         Return a pcl.VoxelGridFilter object with this object set as the input-cloud
         """
-        fil = VoxelGridFilter()
+        fil = VoxelGridFilter_PointXYZRGBA()
         cdef pcl_fil.VoxelGrid_PointXYZRGBA_t *cfil = <pcl_fil.VoxelGrid_PointXYZRGBA_t *>fil.me
         cfil.setInputCloud(<cpp.shared_ptr[cpp.PointCloud[cpp.PointXYZRGBA]]> self.thisptr_shared)
         return fil

--- a/pcl/pxi/PointCloud_PointXYZRGBA_172.pxi
+++ b/pcl/pxi/PointCloud_PointXYZRGBA_172.pxi
@@ -316,7 +316,7 @@ cdef class PointCloud_PointXYZRGBA:
         """
         Return a pcl.VoxelGridFilter object with this object set as the input-cloud
         """
-        fil = VoxelGridFilter()
+        fil = VoxelGridFilter_PointXYZRGBA()
         cdef pcl_fil.VoxelGrid_PointXYZRGBA_t *cfil = <pcl_fil.VoxelGrid_PointXYZRGBA_t *>fil.me
         cfil.setInputCloud(<cpp.shared_ptr[cpp.PointCloud[cpp.PointXYZRGBA]]> self.thisptr_shared)
         return fil

--- a/pcl/pxi/PointCloud_PointXYZRGBA_180.pxi
+++ b/pcl/pxi/PointCloud_PointXYZRGBA_180.pxi
@@ -316,7 +316,7 @@ cdef class PointCloud_PointXYZRGBA:
         """
         Return a pcl.VoxelGridFilter object with this object set as the input-cloud
         """
-        fil = VoxelGridFilter()
+        fil = VoxelGridFilter_PointXYZRGBA()
         cdef pcl_fil.VoxelGrid_PointXYZRGBA_t *cfil = <pcl_fil.VoxelGrid_PointXYZRGBA_t *>fil.me
         cfil.setInputCloud(<cpp.shared_ptr[cpp.PointCloud[cpp.PointXYZRGBA]]> self.thisptr_shared)
         return fil


### PR DESCRIPTION
Voxel filter for XYZRGBA  point clouds returned colorless point clouds, but this seems unintentional and probably a leftover bug from a copy and paste .

Fix tested successfully on Win64 via a MSVC 2017 build on Python 3.7.3 with PCL 1.8.1.