### PR TITLE
 Added: set/get_eps_angle and set/get_axis to SACSegmentation classes 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ pip-log.txt
 
 # Vim
 *.sw[op]
+
+# PyCharm
+.idea/

--- a/pcl/pxi/Segmentation/Segmentation.pxi
+++ b/pcl/pxi/Segmentation/Segmentation.pxi
@@ -43,8 +43,27 @@ cdef class Segmentation:
         self.me.setDistanceThreshold (d)
 
 
-    def set_MaxIterations(self, int count):
+    def set_max_iterations(self, int count):
         self.me.setMaxIterations (count)
+
+
+    def set_eps_angle(self, double ea):
+        (<pcl_seg.SACSegmentation_t*>self.me).setEpsAngle (ea)
+
+
+    def get_eps_angle(self):
+        return (<pcl_seg.SACSegmentation_t*>self.me).getEpsAngle()
+
+
+    def set_axis(self, double ax1, double ax2, double ax3):
+        cdef eigen3.Vector3f* vec = new eigen3.Vector3f(ax1, ax2, ax3)
+        (<pcl_seg.SACSegmentation_t*>self.me).setAxis(deref(vec))
+
+
+    def get_axis(self):
+        vec = (<pcl_seg.SACSegmentation_t*>self.me).getAxis()
+        cdef float *data = vec.data()
+        return np.array([data[0], data[1], data[2]], dtype=np.float32)
 
 
 cdef class Segmentation_PointXYZI:
@@ -83,6 +102,25 @@ cdef class Segmentation_PointXYZI:
         self.me.setDistanceThreshold (d)
 
 
+    def set_eps_angle(self, double ea):
+        (<pcl_seg.SACSegmentation_PointXYZI_t*>self.me).setEpsAngle (ea)
+
+
+    def get_eps_angle(self):
+        return (<pcl_seg.SACSegmentation_PointXYZI_t*>self.me).getEpsAngle()
+
+
+    def set_axis(self, double ax1, double ax2, double ax3):
+        cdef eigen3.Vector3f* vec = new eigen3.Vector3f(ax1, ax2, ax3)
+        (<pcl_seg.SACSegmentation_PointXYZI_t*>self.me).setAxis(deref(vec))
+
+
+    def get_axis(self):
+        vec = (<pcl_seg.SACSegmentation_PointXYZI_t*>self.me).getAxis()
+        cdef float *data = vec.data()
+        return np.array([data[0], data[1], data[2]], dtype=np.float32)
+
+
 cdef class Segmentation_PointXYZRGB:
     """
     Segmentation class for Sample Consensus methods and models
@@ -119,6 +157,25 @@ cdef class Segmentation_PointXYZRGB:
         self.me.setDistanceThreshold (d)
 
 
+    def set_eps_angle(self, double ea):
+        (<pcl_seg.SACSegmentation_PointXYZRGB_t*>self.me).setEpsAngle (ea)
+
+
+    def get_eps_angle(self):
+        return (<pcl_seg.SACSegmentation_PointXYZRGB_t*>self.me).getEpsAngle()
+
+
+    def set_axis(self, double ax1, double ax2, double ax3):
+        cdef eigen3.Vector3f* vec = new eigen3.Vector3f(ax1, ax2, ax3)
+        (<pcl_seg.SACSegmentation_PointXYZRGB_t*>self.me).setAxis(deref(vec))
+
+
+    def get_axis(self):
+        vec = (<pcl_seg.SACSegmentation_PointXYZRGB_t*>self.me).getAxis()
+        cdef float *data = vec.data()
+        return np.array([data[0], data[1], data[2]], dtype=np.float32)
+
+
 cdef class Segmentation_PointXYZRGBA:
     """
     Segmentation class for Sample Consensus methods and models
@@ -153,5 +210,24 @@ cdef class Segmentation_PointXYZRGBA:
 
     def set_distance_threshold(self, float d):
         self.me.setDistanceThreshold (d)
+
+
+    def set_eps_angle(self, double ea):
+        (<pcl_seg.SACSegmentation_PointXYZRGBA_t*>self.me).setEpsAngle (ea)
+
+
+    def get_eps_angle(self):
+        return (<pcl_seg.SACSegmentation_PointXYZRGBA_t*>self.me).getEpsAngle()
+
+
+    def set_axis(self, double ax1, double ax2, double ax3):
+        cdef eigen3.Vector3f* vec = new eigen3.Vector3f(ax1, ax2, ax3)
+        (<pcl_seg.SACSegmentation_PointXYZRGBA_t*>self.me).setAxis(deref(vec))
+
+
+    def get_axis(self):
+        vec = (<pcl_seg.SACSegmentation_PointXYZRGBA_t*>self.me).getAxis()
+        cdef float *data = vec.data()
+        return np.array([data[0], data[1], data[2]], dtype=np.float32)
 
 

--- a/pcl/pxi/Segmentation/Segmentation_172.pxi
+++ b/pcl/pxi/Segmentation/Segmentation_172.pxi
@@ -43,8 +43,27 @@ cdef class Segmentation:
         self.me.setDistanceThreshold (d)
 
 
-    def set_MaxIterations(self, int count):
+    def set_max_iterations(self, int count):
         self.me.setMaxIterations (count)
+
+
+    def set_eps_angle(self, double ea):
+        (<pcl_seg.SACSegmentation_t*>self.me).setEpsAngle (ea)
+
+
+    def get_eps_angle(self):
+        return (<pcl_seg.SACSegmentation_t*>self.me).getEpsAngle()
+
+
+    def set_axis(self, double ax1, double ax2, double ax3):
+        cdef eigen3.Vector3f* vec = new eigen3.Vector3f(ax1, ax2, ax3)
+        (<pcl_seg.SACSegmentation_t*>self.me).setAxis(deref(vec))
+
+
+    def get_axis(self):
+        vec = (<pcl_seg.SACSegmentation_t*>self.me).getAxis()
+        cdef float *data = vec.data()
+        return np.array([data[0], data[1], data[2]], dtype=np.float32)
 
 
 cdef class Segmentation_PointXYZI:
@@ -83,6 +102,25 @@ cdef class Segmentation_PointXYZI:
         self.me.setDistanceThreshold (d)
 
 
+    def set_eps_angle(self, double ea):
+        (<pcl_seg.SACSegmentation_PointXYZI_t*>self.me).setEpsAngle (ea)
+
+
+    def get_eps_angle(self):
+        return (<pcl_seg.SACSegmentation_PointXYZI_t*>self.me).getEpsAngle()
+
+
+    def set_axis(self, double ax1, double ax2, double ax3):
+        cdef eigen3.Vector3f* vec = new eigen3.Vector3f(ax1, ax2, ax3)
+        (<pcl_seg.SACSegmentation_PointXYZI_t*>self.me).setAxis(deref(vec))
+
+
+    def get_axis(self):
+        vec = (<pcl_seg.SACSegmentation_PointXYZI_t*>self.me).getAxis()
+        cdef float *data = vec.data()
+        return np.array([data[0], data[1], data[2]], dtype=np.float32)
+
+
 cdef class Segmentation_PointXYZRGB:
     """
     Segmentation class for Sample Consensus methods and models
@@ -117,6 +155,25 @@ cdef class Segmentation_PointXYZRGB:
 
     def set_distance_threshold(self, float d):
         self.me.setDistanceThreshold (d)
+
+
+    def set_eps_angle(self, double ea):
+        (<pcl_seg.SACSegmentation_PointXYZRGB_t*>self.me).setEpsAngle (ea)
+
+
+    def get_eps_angle(self):
+        return (<pcl_seg.SACSegmentation_PointXYZRGB_t*>self.me).getEpsAngle()
+
+
+    def set_axis(self, double ax1, double ax2, double ax3):
+        cdef eigen3.Vector3f* vec = new eigen3.Vector3f(ax1, ax2, ax3)
+        (<pcl_seg.SACSegmentation_PointXYZRGB_t*>self.me).setAxis(deref(vec))
+
+
+    def get_axis(self):
+        vec = (<pcl_seg.SACSegmentation_PointXYZRGB_t*>self.me).getAxis()
+        cdef float *data = vec.data()
+        return np.array([data[0], data[1], data[2]], dtype=np.float32)
 
 
 cdef class Segmentation_PointXYZRGBA:
@@ -154,4 +211,22 @@ cdef class Segmentation_PointXYZRGBA:
     def set_distance_threshold(self, float d):
         self.me.setDistanceThreshold (d)
 
+
+    def set_eps_angle(self, double ea):
+        (<pcl_seg.SACSegmentation_PointXYZRGBA_t*>self.me).setEpsAngle (ea)
+
+
+    def get_eps_angle(self):
+        return (<pcl_seg.SACSegmentation_PointXYZRGBA_t*>self.me).getEpsAngle()
+
+
+    def set_axis(self, double ax1, double ax2, double ax3):
+        cdef eigen3.Vector3f* vec = new eigen3.Vector3f(ax1, ax2, ax3)
+        (<pcl_seg.SACSegmentation_PointXYZRGBA_t*>self.me).setAxis(deref(vec))
+
+
+    def get_axis(self):
+        vec = (<pcl_seg.SACSegmentation_PointXYZRGBA_t*>self.me).getAxis()
+        cdef float *data = vec.data()
+        return np.array([data[0], data[1], data[2]], dtype=np.float32)
 

--- a/pcl/pxi/Segmentation/Segmentation_180.pxi
+++ b/pcl/pxi/Segmentation/Segmentation_180.pxi
@@ -43,8 +43,27 @@ cdef class Segmentation:
         self.me.setDistanceThreshold (d)
 
 
-    def set_MaxIterations(self, int count):
+    def set_max_iterations(self, int count):
         self.me.setMaxIterations (count)
+
+
+    def set_eps_angle(self, double ea):
+        (<pcl_seg.SACSegmentation_t*>self.me).setEpsAngle (ea)
+
+
+    def get_eps_angle(self):
+        return (<pcl_seg.SACSegmentation_t*>self.me).getEpsAngle()
+
+
+    def set_axis(self, double ax1, double ax2, double ax3):
+        cdef eigen3.Vector3f* vec = new eigen3.Vector3f(ax1, ax2, ax3)
+        (<pcl_seg.SACSegmentation_t*>self.me).setAxis(deref(vec))
+
+
+    def get_axis(self):
+        vec = (<pcl_seg.SACSegmentation_t*>self.me).getAxis()
+        cdef float *data = vec.data()
+        return np.array([data[0], data[1], data[2]], dtype=np.float32)
 
 
 cdef class Segmentation_PointXYZI:
@@ -83,6 +102,25 @@ cdef class Segmentation_PointXYZI:
         self.me.setDistanceThreshold (d)
 
 
+    def set_eps_angle(self, double ea):
+        (<pcl_seg.SACSegmentation_PointXYZI_t*>self.me).setEpsAngle (ea)
+
+
+    def get_eps_angle(self):
+        return (<pcl_seg.SACSegmentation_PointXYZI_t*>self.me).getEpsAngle()
+
+
+    def set_axis(self, double ax1, double ax2, double ax3):
+        cdef eigen3.Vector3f* vec = new eigen3.Vector3f(ax1, ax2, ax3)
+        (<pcl_seg.SACSegmentation_PointXYZI_t*>self.me).setAxis(deref(vec))
+
+
+    def get_axis(self):
+        vec = (<pcl_seg.SACSegmentation_PointXYZI_t*>self.me).getAxis()
+        cdef float *data = vec.data()
+        return np.array([data[0], data[1], data[2]], dtype=np.float32)
+
+
 cdef class Segmentation_PointXYZRGB:
     """
     Segmentation class for Sample Consensus methods and models
@@ -117,6 +155,24 @@ cdef class Segmentation_PointXYZRGB:
 
     def set_distance_threshold(self, float d):
         self.me.setDistanceThreshold (d)
+
+
+    def set_eps_angle(self, double ea):
+        (<pcl_seg.SACSegmentation_PointXYZRGB_t*>self.me).setEpsAngle (ea)
+
+    def get_eps_angle(self):
+        return (<pcl_seg.SACSegmentation_PointXYZRGB_t*>self.me).getEpsAngle()
+
+
+    def set_axis(self, double ax1, double ax2, double ax3):
+        cdef eigen3.Vector3f* vec = new eigen3.Vector3f(ax1, ax2, ax3)
+        (<pcl_seg.SACSegmentation_PointXYZRGB_t*>self.me).setAxis(deref(vec))
+
+
+    def get_axis(self):
+        vec = (<pcl_seg.SACSegmentation_PointXYZRGB_t*>self.me).getAxis()
+        cdef float *data = vec.data()
+        return np.array([data[0], data[1], data[2]], dtype=np.float32)
 
 
 cdef class Segmentation_PointXYZRGBA:
@@ -154,4 +210,22 @@ cdef class Segmentation_PointXYZRGBA:
     def set_distance_threshold(self, float d):
         self.me.setDistanceThreshold (d)
 
+
+    def set_eps_angle(self, double ea):
+        (<pcl_seg.SACSegmentation_PointXYZRGBA_t*>self.me).setEpsAngle (ea)
+
+
+    def get_eps_angle(self):
+        return (<pcl_seg.SACSegmentation_PointXYZRGBA_t*>self.me).getEpsAngle()
+
+
+    def set_axis(self, double ax1, double ax2, double ax3):
+        cdef eigen3.Vector3f* vec = new eigen3.Vector3f(ax1, ax2, ax3)
+        (<pcl_seg.SACSegmentation_PointXYZRGBA_t*>self.me).setAxis(deref(vec))
+
+
+    def get_axis(self):
+        vec = (<pcl_seg.SACSegmentation_PointXYZRGBA_t*>self.me).getAxis()
+        cdef float *data = vec.data()
+        return np.array([data[0], data[1], data[2]], dtype=np.float32)
 


### PR DESCRIPTION
I needed to use this piece of code in the project I'm working on:

```
    seg = cloud.make_segmenter()
    seg.set_optimize_coefficients(True)
    seg.set_model_type(pcl.SACMODEL_PERPENDICULAR_PLANE)
    seg.set_method_type(pcl.SAC_RANSAC)
    seg.set_axis(0., 1.0, 1.0)
    seg.set_eps_angle(math.pi/4)
    seg.set_distance_threshold(0.1)
    indices, coefficients = seg.segment()
```

But I found `seg.set_axis(...)` and `seg.set_eps_angle(...)` where non-existing, so I added them to pcl/pxi/Segmentation.pxi (and to the rest of Segmentation_*.pxi).

Cheers :)
