### PR TITLE
Correct rotation matrix construction in TestICP

### DIFF
--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -20,8 +20,8 @@ class TestICP(unittest.TestCase):
         rot_y = [[cos(theta[1]), 0, sin(theta[1])],
                  [0, 1, 0],
                  [-sin(theta[1]), 0, cos(theta[1])]]
-        rot_z = [[cos(theta[2]), -sin(theta[1]), 0],
-                 [sin(theta[2]), cos(theta[1]), 0],
+        rot_z = [[cos(theta[2]), -sin(theta[2]), 0],
+                 [sin(theta[2]), cos(theta[2]), 0],
                  [0, 0, 1]]
         transform = np.dot(rot_x, np.dot(rot_y, rot_z))
 


### PR DESCRIPTION
Typo correction in rot_z for matrix construction.
These functions are local and not relevant to the test, so this will not break (or fix) anything.
